### PR TITLE
Improve HDF5 feature lookups for visualization

### DIFF
--- a/generate_visuals.py
+++ b/generate_visuals.py
@@ -82,10 +82,10 @@ def main(dataset: str, method: str, seg_tag: str | None, query_id: str | None, o
     cand_img = io.load_image(cand_path)
 
     # load keypoints and descriptors
-    q_kp = io.load_keypoints_h5(test_kp_h5, [query_id]).get(query_id)
-    q_desc = io.load_descriptors_h5(test_desc_h5, [query_id]).get(query_id)
-    t_kp = io.load_keypoints_h5(train_kp_h5, [candidate_id]).get(candidate_id)
-    t_desc = io.load_descriptors_h5(train_desc_h5, [candidate_id]).get(candidate_id)
+    q_kp = io.load_keypoints_h5(test_kp_h5, [query_id]).get(str(query_id))
+    q_desc = io.load_descriptors_h5(test_desc_h5, [query_id]).get(str(query_id))
+    t_kp = io.load_keypoints_h5(train_kp_h5, [candidate_id]).get(str(candidate_id))
+    t_desc = io.load_descriptors_h5(train_desc_h5, [candidate_id]).get(str(candidate_id))
 
     if q_kp is None or q_desc is None:
         raise ValueError(f"Features for query ID {query_id} not found in HDF5 stores")

--- a/visualization_suite/io.py
+++ b/visualization_suite/io.py
@@ -68,9 +68,22 @@ def load_keypoints_h5(h5_path: str, ids: Sequence[str]) -> Dict[str, np.ndarray]
     """
     data: Dict[str, np.ndarray] = {}
     with h5py.File(h5_path, "r") as f:
+        # Determine zero-padding length from any existing key (if numeric)
+        pad_len = None
+        keys = list(f.keys())
+        if keys:
+            sample_key = keys[0]
+            if sample_key.isdigit():
+                pad_len = len(sample_key)
+
         for image_id in ids:
-            if image_id in f:
-                data[image_id] = np.array(f[image_id])
+            key = str(image_id)
+            if key not in f and pad_len and key.isdigit():
+                key = key.zfill(pad_len)
+            if key in f:
+                # Store under the original id (as string) so callers can use
+                # their provided identifier regardless of padding.
+                data[str(image_id)] = np.array(f[key])
     return data
 
 
@@ -78,7 +91,17 @@ def load_descriptors_h5(h5_path: str, ids: Sequence[str]) -> Dict[str, np.ndarra
     """Load descriptors for ``ids`` from an HDF5 file."""
     data: Dict[str, np.ndarray] = {}
     with h5py.File(h5_path, "r") as f:
+        pad_len = None
+        keys = list(f.keys())
+        if keys:
+            sample_key = keys[0]
+            if sample_key.isdigit():
+                pad_len = len(sample_key)
+
         for image_id in ids:
-            if image_id in f:
-                data[image_id] = np.array(f[image_id])
+            key = str(image_id)
+            if key not in f and pad_len and key.isdigit():
+                key = key.zfill(pad_len)
+            if key in f:
+                data[str(image_id)] = np.array(f[key])
     return data


### PR DESCRIPTION
## Summary
- Allow HDF5 loaders to resolve image IDs regardless of zero-padding
- Ensure visualisation script treats all IDs as strings when fetching features

## Testing
- `python -m py_compile visualization_suite/io.py generate_visuals.py`
- `pytest` *(fails: fixture 'dataset_name' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2e9d54f883249c706f16da3c573a